### PR TITLE
Conditionally revert "Revert "sf: Make sure HWC_BLENDING_NONE is set for...

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -477,7 +477,12 @@ void Layer::setGeometry(
 
     // this gives us only the "orientation" component of the transform
     const State& s(getDrawingState());
-    if (!isOpaque(s) || s.alpha != 0xFF) {
+#ifdef QCOM_BSP_LEGACY
+    if (!isOpaque(s))
+#else
+    if (!isOpaque(s) || s.alpha != 0xFF)
+#endif
+    {
         layer.setBlending(mPremultipliedAlpha ?
                 HWC_BLENDING_PREMULT :
                 HWC_BLENDING_COVERAGE);


### PR DESCRIPTION
... opaque layer""

 * This behavior is REQUIRED on newer Qualcomm hardware, or undefined
   behavior such as artifacts or garbage will appear. Scope this revert
   to QCOM_BSP_LEGACY only!

This reverts commit 1816143805334acb6f7b15da36eb13ba308b68ef.

Change-Id: I1f5bb57d1fa8750e854f01884bb675e4b9f2bed5